### PR TITLE
Fix the posting time text size

### DIFF
--- a/src/UserStories/UserStories.js
+++ b/src/UserStories/UserStories.js
@@ -194,7 +194,7 @@ export function UserStories({ userId }) {
                       'is-small': !activeStory,
                     })}
                   >
-                    {absoluteToRelativeDate(story.posting_time)}
+                    {absoluteToRelativeDate(story.posting_time, 'mini')}
                   </p>
 
                   {activeStory ? (

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,6 @@ const timeAgo = new TimeAgo("en-US");
  * @param {Date} date the JS date object
  * @returns {string} the relative time/date
  */
-export function absoluteToRelativeDate(date) {
-  return timeAgo.format(new Date(date), 'mini');
+export function absoluteToRelativeDate(date, dateTextSize) {
+  return timeAgo.format(new Date(date), dateTextSize);
 }


### PR DESCRIPTION
It's now a lengthier text that shows the word month week day and ago instead of the first letter of those words in post.
And it's just the first letter in UserStroies just like the real IG.
Fixes issue #16.