### PR TITLE
Add color to comment input in posts

### DIFF
--- a/src/Post/Post.css
+++ b/src/Post/Post.css
@@ -187,9 +187,14 @@ section.comment-input-section {
 }
 .comment-input {
   width: 100%;
-  border: none;
+  border: 0;
   background: none;
   padding-left: 20px;
+  outline: none;
+}
+.comment-input::placeholder {
+  color: #8e8e8e;
+  font-size: 14px;
 }
 .post-button {
   background: none;


### PR DESCRIPTION
Added a grey colour to the input's placeholder and removed the border when the input is in use.
Fixes issue #17.